### PR TITLE
ensure `~/.Brewfile` opens with Ruby hashbang

### DIFF
--- a/update
+++ b/update
@@ -114,7 +114,10 @@ if command -v -- python3 >/dev/null 2>&1; then
 fi
 if command -v -- brew >/dev/null 2>&1; then
   command brew generate-man-completions --debug --verbose 2>/dev/null
-  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --tap --verbose --whalebrew | command sed -e '$!N' -e '/^#.*\n[^#]/s/\n/\t/' -e 'P' -e 'D' | command awk -F '\t' -- '{print $2 $1}' | command sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command sort -f | command sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/' >"${HOME-}"'/.Brewfile'
+  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --tap --verbose --whalebrew | command sed -e '$!N' -e '/^#.*\n[^#]/s/\n/\t/' -e 'P' -e 'D' | command awk -F '\t' -- '{print $2 $1}' | command sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command sort -f | {
+    printf '#!/usr/bin/env ruby\n'
+    command sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/'
+  } >"${HOME-}"'/.Brewfile'
 fi
 if command -v -- omz >/dev/null 2>&1; then omz update 2>/dev/null; fi
 # shellcheck source=/dev/null


### PR DESCRIPTION
`~/.Brewfile`, which is a [well-formed Ruby file](https://github.com/LucasLarson/dotfiles/blob/1fffd32db4/.Brewfile) merits opening like this,[^1] which will fix #16:

```ruby
#!/usr/bin/env ruby
```

but as of the creation of #17, no hashbang is added:
https://github.com/LucasLarson/update/blob/b23929246f4a7f97efc739bd6faf69f4ec6410c1/update#L117

[^1]: [LucasLarson/dotfiles@`1fffd32db4`](https://github.com/LucasLarson/dotfiles/commit/1fffd32db4)