### PR TITLE
send informational text to standard error

### DIFF
--- a/update
+++ b/update
@@ -3,26 +3,26 @@ update='1'
 IFS="$(printf -- ' \t\n|')"
 IFS="${IFS%'|'}"
 command tput -- clear
-printf -- '                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' 2>/dev/null && command sleep 1
+printf -- '                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command sleep 1
 unset -v -- PS4 2>/dev/null
-printf -- '\360\237\223\241  verifying network connectivity' 2>/dev/null
+printf -- '\360\237\223\241  verifying network connectivity' >&2
 command sleep 1
 i='0'
 while test "${i-}" -lt "$(printf -- '2 ^ 7 + 1\n' | command bc)"; do
-  if test "$((i / 3 % 2))" -eq '0'; then printf -- '.' 2>/dev/null; else printf -- '\b' 2>/dev/null; fi
+  if test "$((i / 3 % 2))" -eq '0'; then printf -- '.' >&2; else printf -- '\b' >&2; fi
   i="$((i + 1))"
 done
 unset -v -- i 2>/dev/null
-printf -- '\n\n' 2>/dev/null
+printf -- '\n\n' >&2
 { command ping -c 1 -- one.one.one.one >/dev/null 2>&1 && command ping -c 1 -- 8.8.8.8 >/dev/null 2>&1; } || {
   update="${?-}"
-  printf -- 'No internet connection detected.\nAborting update.\n' 2>/dev/null
+  printf -- 'No internet connection detected.\nAborting update.\n' >&2
   return "${update:-1}"
 }
-printf -- '\360\237\215\272  checking for Homebrew installation...' 2>/dev/null
+printf -- '\360\237\215\272  checking for Homebrew installation...' >&2
 if command -v -- brew >/dev/null 2>&1; then
-  printf -- '  \342\234\205  found\n' 2>/dev/null
-  printf -- '\360\237\215\272  checking for Homebrew updates...\n' 2>/dev/null
+  printf -- '  \342\234\205  found\n' >&2
+  printf -- '\360\237\215\272  checking for Homebrew updates...\n' >&2
   command brew update
   command defaults export com.apple.dock "${TMPDIR:-${TMPPREFIX:-/tmp}}"'/.com.apple.dock.plist' >/dev/null 2>&1 && {
     command brew upgrade --cask --greedy
@@ -34,83 +34,83 @@ if command -v -- brew >/dev/null 2>&1; then
   command brew install --debug --display-times --git --HEAD --verbose -- shellcheck
   command brew install --debug --display-times --git --HEAD --verbose -- shfmt
   command brew install --debug --display-times --git --HEAD --verbose -- zsh
-else printf -- 'No Homebrew installation detected.\n\n' 2>/dev/null; fi
-printf -- '\360\237\217\224  checking for Alpine Package Keeper installation...\n' 2>/dev/null
+else printf -- 'No Homebrew installation detected.\n\n' >&2; fi
+printf -- '\360\237\217\224  checking for Alpine Package Keeper installation...\n' >&2
 if command -v -- apk >/dev/null 2>&1; then
-  printf -- '\360\237\217\224  apk update...\n' 2>/dev/null
+  printf -- '\360\237\217\224  apk update...\n' >&2
   command apk update --progress --verbose --verbose
-  printf -- '\n\360\237\217\224  apk upgrade...\n' 2>/dev/null
+  printf -- '\n\360\237\217\224  apk upgrade...\n' >&2
   command apk upgrade --progress --update-cache --verbose --verbose
-  printf -- '\n\360\237\217\224  apk fix...\n' 2>/dev/null
+  printf -- '\n\360\237\217\224  apk fix...\n' >&2
   command apk fix --progress --verbose --verbose
-  printf -- '\n\360\237\217\224  apk verify...\n' 2>/dev/null
+  printf -- '\n\360\237\217\224  apk verify...\n' >&2
   command apk verify --progress --verbose --verbose
-  printf -- '\360\237\217\224  apk verify complete...\n\n' 2>/dev/null
-else printf -- 'no Alpine Package Keeper installation detected.\n\n' 2>/dev/null; fi
-printf -- 'checking access to Software Update...\n' 2>/dev/null
+  printf -- '\360\237\217\224  apk verify complete...\n\n' >&2
+else printf -- 'no Alpine Package Keeper installation detected.\n\n' >&2; fi
+printf -- 'checking access to Software Update...\n' >&2
 if command -v -- softwareupdate >/dev/null 2>&1; then
-  printf -- '\360\237\215\216  ' 2>/dev/null
+  printf -- '\360\237\215\216  ' >&2
   command softwareupdate --all --list --verbose
-else printf -- 'no Software Update installation detected.\n\n' 2>/dev/null; fi
-printf -- 'checking for Xcode installation...\n' 2>/dev/null
+else printf -- 'no Software Update installation detected.\n\n' >&2; fi
+printf -- 'checking for Xcode installation...\n' >&2
 if command -v -- xcrun >/dev/null 2>&1; then
-  printf -- 'removing unavailable device simulators...\n' 2>/dev/null
+  printf -- 'removing unavailable device simulators...\n' >&2
   command xcrun simctl delete unavailable
-else printf -- 'no Xcode installation detected.\n\n' 2>/dev/null; fi
-printf -- '\342\232\233\357\270\217  checking for Atom installation...\n' 2>/dev/null
-if command -v -- apm >/dev/null 2>&1; then command apm upgrade --no-confirm; else printf -- 'no Atom installation detected.\n\n' 2>/dev/null; fi
-printf -- '\360\237\246\200  checking for Rust installation...\n' 2>/dev/null
-if command -v -- rustup >/dev/null 2>&1; then command rustup --verbose update; else printf -- 'no Rust installation detected.\n\n' 2>/dev/null; fi
-printf -- 'checking for npm installation...\n' 2>/dev/null
+else printf -- 'no Xcode installation detected.\n\n' >&2; fi
+printf -- '\342\232\233\357\270\217  checking for Atom installation...\n' >&2
+if command -v -- apm >/dev/null 2>&1; then command apm upgrade --no-confirm; else printf -- 'no Atom installation detected.\n\n' >&2; fi
+printf -- '\360\237\246\200  checking for Rust installation...\n' >&2
+if command -v -- rustup >/dev/null 2>&1; then command rustup --verbose update; else printf -- 'no Rust installation detected.\n\n' >&2; fi
+printf -- 'checking for npm installation...\n' >&2
 if command -v -- npm >/dev/null 2>&1; then
-  printf -- '...and whether this device is can update Node quickly...\n' 2>/dev/null
+  printf -- '...and whether this device is can update Node quickly...\n' >&2
   if test "$(command getconf -- LONG_BIT)" -gt 32; then
     while test -n "$(command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -delete; done
     command npm install npm --location=global
     while test -n "$(command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -delete; done
     command npm update --location=global --loglevel=verbose
   else
-    printf -- 'skipping Node update...\n\n' 2>/dev/null
+    printf -- 'skipping Node update...\n\n' >&2
     command sleep 1
-    printf -- 'to update Node later, run:\n\n' 2>/dev/null
-    printf -- '    npm install npm --location=global \046\046 \134\n' 2>/dev/null
-    printf -- '    npm update --location=global --loglevel=verbose\n\n\n' 2>/dev/null
+    printf -- 'to update Node later, run:\n\n' >&2
+    printf -- '    npm install npm --location=global \046\046 \134\n' >&2
+    printf -- '    npm update --location=global --loglevel=verbose\n\n\n' >&2
     command sleep 3
   fi
   command npm ls --json --location=global --loglevel=verbose >"${DOTFILES:-${HOME-}}"'/.package-list.json'
-else printf -- 'no npm installation detected.\n\n' 2>/dev/null; fi
-printf -- 'checking for RubyGems installation...\n' 2>/dev/null
+else printf -- 'no npm installation detected.\n\n' >&2; fi
+printf -- 'checking for RubyGems installation...\n' >&2
 if command -v -- gem >/dev/null 2>&1; then
-  printf -- 'updating RubyGems...\n' 2>/dev/null
+  printf -- 'updating RubyGems...\n' >&2
   command gem update --system --verbose
   command gem update --verbose
   if command bundle update >/dev/null 2>&1; then command bundle update --verbose 2>/dev/null; fi
   if command bundle install >/dev/null 2>&1; then command bundle install --verbose 2>/dev/null; fi
-  printf -- 'checking for CocoaPods installation...\n' 2>/dev/null
+  printf -- 'checking for CocoaPods installation...\n' >&2
   if command bundle exec pod install >/dev/null 2>&1; then command bundle exec pod install --verbose 2>/dev/null; fi
   if command pod repo update >/dev/null 2>&1; then
     command pod repo update --verbose
     command pod repo update --verbose
   fi
-else printf -- 'no RubyGems installation detected.\n\n' 2>/dev/null; fi
+else printf -- 'no RubyGems installation detected.\n\n' >&2; fi
 if command -v -- rbenv >/dev/null 2>&1; then command rbenv rehash; fi
 if command -v -- c_rehash >/dev/null 2>&1; then command c_rehash; fi
 if command -v -- python3 >/dev/null 2>&1; then
-  printf -- '\n\360\237\220\215  verifying Python\342\200\231s packager is up to date...\n' 2>/dev/null
+  printf -- '\n\360\237\220\215  verifying Python\342\200\231s packager is up to date...\n' >&2
   command python3 -m pip install --upgrade --verbose --verbose -- pip
-  printf -- 'verifying pip installation...\n' 2>/dev/null
+  printf -- 'verifying pip installation...\n' >&2
   if command -v -- pip >/dev/null 2>&1; then
-    printf -- '\n\360\237\220\215  updating outdated Python packages...\n' 2>/dev/null
+    printf -- '\n\360\237\220\215  updating outdated Python packages...\n' >&2
     command pip list --outdated | command awk -- 'NR > 2 {print $1}' | while IFS='' read -r package; do command pip install --upgrade --verbose --verbose -- "${package%%=*}"; done
     unset -v -- package 2>/dev/null
   fi
-  printf -- 'checking for pyenv installation...\n' 2>/dev/null
+  printf -- 'checking for pyenv installation...\n' >&2
   if command -v -- pyenv >/dev/null 2>&1; then
-    printf -- 'rehashing pyenv shims...\n' 2>/dev/null
+    printf -- 'rehashing pyenv shims...\n' >&2
     command pyenv rehash
-  else printf -- 'no pyenv installation detected.\n\n' 2>/dev/null; fi
-  printf -- 'checking for Conda installation...\n' 2>/dev/null
-  if command -v -- conda >/dev/null 2>&1; then command conda update --all --yes; else printf -- 'no Conda installation detected.\n\n' 2>/dev/null; fi
+  else printf -- 'no pyenv installation detected.\n\n' >&2; fi
+  printf -- 'checking for Conda installation...\n' >&2
+  if command -v -- conda >/dev/null 2>&1; then command conda update --all --yes; else printf -- 'no Conda installation detected.\n\n' >&2; fi
 fi
 if command -v -- brew >/dev/null 2>&1; then
   command brew generate-man-completions --debug --verbose 2>/dev/null
@@ -124,5 +124,5 @@ if command -v -- omz >/dev/null 2>&1; then omz update 2>/dev/null; fi
 test -r "${HOME-}"'/.'"${SHELL##*[-./]}"'rc' && . "${HOME-}"'/.'"${SHELL##*[-./]}"'rc'
 if command -v -- rehash >/dev/null 2>&1; then rehash; fi
 unset -v -- update 2>/dev/null
-printf -- '\n\342%s\234\205  update complete\n' "${update-}" 2>/dev/null
+printf -- '\n\342%s\234\205  update complete\n' "${update-}" >&2
 "$(command -v -- exec)" -l -- "${SHELL##*[-./]}"


### PR DESCRIPTION
informative and decorative text generated by `printf` should be printed to standard error (`>&2`) instead of standard output (`​`) to fix #18.