### PR TITLE
use more common npm syntax

### DIFF
--- a/update
+++ b/update
@@ -65,15 +65,15 @@ printf -- 'checking for npm installation...\n' >&2
 if command -v -- npm >/dev/null 2>&1; then
   printf -- '...and whether this device is can update Node quickly...\n' >&2
   if test "$(command getconf -- LONG_BIT)" -gt 32; then
-    while test -n "$(command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -delete; done
-    command npm install npm --location=global
-    while test -n "$(command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config get prefix --location=global)" -name '.DS_Store' -type f -delete; done
+    while test -n "$(command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
+    command npm install --location=global npm
+    while test -n "$(command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)"; do command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
     command npm update --location=global --loglevel=verbose
   else
     printf -- 'skipping Node update...\n\n' >&2
     command sleep 1
     printf -- 'to update Node later, run:\n\n' >&2
-    printf -- '    npm install npm --location=global \046\046 \134\n' >&2
+    printf -- '    npm install --location=global npm \046\046 \134\n' >&2
     printf -- '    npm update --location=global --loglevel=verbose\n\n\n' >&2
     command sleep 3
   fi


### PR DESCRIPTION
`npm i -g npm` and the like[^1] are much more common than `npm i npm -g`;[^2] this commit moves the `--location=global` (`-g`) and `--log-level=verbose` (`-d`, `--dd`, `--verbose`) arguments into that order to fix #20

[^1]: [`/npm[[:blank:]][[:blank:]]*(add|i(nstall|n|ns|nst|nsta|nstal|snt|snta|sntal|sntall)?)[[:blank:]][[:blank:]]*.*-(g|-global|-location.global)[[:blank:]][[:blank:]]*npm/`](https://github.com/search?type=code&q=%2Fnpm%5B%5B%3Ablank%3A%5D%5D%5B%5B%3Ablank%3A%5D%5D*%28add%7Ci%28nstall%7Cn%7Cns%7Cnst%7Cnsta%7Cnstal%7Csnt%7Csnta%7Csntal%7Csntall%29%3F%29%5B%5B%3Ablank%3A%5D%5D%5B%5B%3Ablank%3A%5D%5D*npm[[:blank:]][[:blank:]]*-%28g%7C-global%7C-location.global%29%5B%5B%3Ablank%3A%5D%5D%5B%5B%3Ablank%3A%5D%5D%2F)
[^2]: [`/npm[[:blank:]][[:blank:]]*(add|i(nstall|n|ns|nst|nsta|nstal|snt|snta|sntal|sntall)?)[[:blank:]][[:blank:]]*npm[[:blank:]][[:blank:]]*-(g|-global|-location.global)/`
](https://github.com/search?type=code&q=%2Fnpm%5B%5B%3Ablank%3A%5D%5D%5B%5B%3Ablank%3A%5D%5D*%28add%7Ci%28nstall%7Cn%7Cns%7Cnst%7Cnsta%7Cnstal%7Csnt%7Csnta%7Csntal%7Csntall%29%3F%29%5B%5B%3Ablank%3A%5D%5D%5B%5B%3Ablank%3A%5D%5D*npm[[:blank:]][[:blank:]]*-%28g%7C-global%7C-location.global%29%2F)