### PR TITLE
skip loading run-commands file load before shell restart

### DIFF
--- a/update
+++ b/update
@@ -120,8 +120,6 @@ if command -v -- brew >/dev/null 2>&1; then
   } >"${HOME%/}"'/.Brewfile'
 fi
 if command -v -- omz >/dev/null 2>&1; then omz update 2>/dev/null; fi
-# shellcheck disable=SC1090
-test -r "${HOME%/}"'/.'"$(command basename -- "${SHELL%%[0-9-]*}")"'rc' && . "${HOME%/}"'/.'"$(command basename -- "${SHELL%%[0-9-]*}")"'rc'
 if command -v -- rehash >/dev/null 2>&1; then rehash; fi
 update=''
 unset -v -- update 2>/dev/null


### PR DESCRIPTION
Do not load a run-commands file...
https://github.com/LucasLarson/update/blob/4b5a661f6458c322e3542b5dc6f0b78583787bfe/update#L124
...directly before restarting the shell...
https://github.com/LucasLarson/update/blob/90b99823f80108a394cba5fd02aaa11b46e28d0a/update#L128
...because they perform almost the same function, but the latter duplicates the work of – and also undoes and overrides – the former
