### PR TITLE
ensure script can be sourced or copied and pasted

### DIFF
--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-update='2023-07-15'
+update='2023-07-16'
 IFS="$(command printf -- ' \t\n|')" && IFS="${IFS%'|'}"
 command printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command sleep 1
 command printf -- '\360\237\223\241  verifying network connectivity' >&2
@@ -130,4 +130,4 @@ if command -v -- rehash >/dev/null 2>&1; then rehash; fi
 update=''
 unset -v -- update 2>/dev/null
 command printf -- '\n\342%s\234\205  update complete\n' "${update-}" >&2
-"$(command -v -- exec)" -l -- "${SHELL##*/}"
+case "${SHELL##*/}" in *"${0##*-}") return ;; *) exit ;; esac


### PR DESCRIPTION
- if not sourced, then `$0`’s value is likely `-sh` or `sh` (or `-zsh` or `zsh`), which without the leading login hyphen `-`, is a terminating substring of `${SHELL##*/}`; this heuristic will determine the appropriate behavior:
	- if sourced (`.`), the script will `exit` upon completion, instead of the old behavior, where a second login shell was generated atop the first one
	- if copied and pasted, the script will `return` without exiting upon completion, but will not close the current shell
- the script will no longer call `exec -l`, which is not defined by POSIX ([SC3038](https://github.com/koalaman/shellcheck/wiki/SC3038/5c927dcdfeb828d274e26a6dafed7f0649077945))