### PR TITLE
perf: prepend POSIX utilities with `command -p`

### DIFF
--- a/update
+++ b/update
@@ -1,33 +1,33 @@
 #!/usr/bin/env sh
-update='2023-10-29'
-IFS="$(command printf -- ' \t\n|')" && IFS="${IFS%'|'}"
-command printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command sleep 1
-command printf -- '\360\237\223\241  verifying network connectivity' >&2
-command sleep 1
+update='2024-01-11'
+IFS="$(command -p -- printf -- ' \t\n|')" && IFS="${IFS%'|'}"
+command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
+command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
+command -p -- sleep 1
 i='0'
-while test "${i-}" -lt "$(command getconf -- CHAR_MAX)"; do
-  if test "$((i / 3 % 2))" -eq '0'; then command printf -- '.' >&2; else command printf -- '\b' >&2; fi
+while test "${i-}" -lt "$(command -p -- getconf -- CHAR_MAX)"; do
+  if test "$((i / 3 % 2))" -eq '0'; then command -p -- printf -- '.' >&2; else command -p -- printf -- '\b' >&2; fi
   i="$((i + 1))"
 done
 i=''
 unset -v -- i 2>/dev/null
-command printf -- '\n\n' >&2
+command -p -- printf -- '\n\n' >&2
 { command ping -c 1 -- one.one.one.one >/dev/null 2>&1 && command ping -c 1 -- 9.9.9.9 >/dev/null 2>&1; } || {
   update="${?-}"
-  command printf -- 'No internet connection detected.\nAborting update.\n' >&2
+  command -p -- printf -- 'No internet connection detected.\nAborting update.\n' >&2
   case "${SHELL##*/}" in *"${0##*-}") return "${update:-1}" ;; *) exit "${update:-1}" ;; esac
 }
 set -- 'https://lucaslarson.net/update'
-command test "$({ command wget --hsts-file=/dev/null --output-document=- --quiet -- "${1-}" || command curl --location --silent -- "${1-}"; } 2>/dev/null | command sed -n -e '/update=/ {' -e 's/[^[:digit:]]//gp' -e 'q' -e '}')" -le "$(command printf -- '%s\n' "${update-}" | command sed -e 's/[^[:digit:]]//g')" || {
-  command printf -- 'An update to this updater is available\041 Download it from here:\n%s\n' "${1-}" >&2
+command -p -- test "$({ command wget --hsts-file=/dev/null --output-document=- --quiet -- "${1-}" || command curl --location --silent -- "${1-}"; } 2>/dev/null | command -p -- sed -n -e '/update=/ {' -e 's/[^[:digit:]]//gp' -e 'q' -e '}')" -le "$(command -p -- printf -- '%s\n' "${update-}" | command -p -- sed -e 's/[^[:digit:]]//g')" || {
+  command -p -- printf -- 'An update to this updater is available\041 Download it from here:\n%s\n' "${1-}" >&2
   update=''
   unset -v -- update 2>/dev/null
   exit
 }
-command printf -- '\360\237\215\272  checking for Homebrew installation...' >&2
+command -p -- printf -- '\360\237\215\272  checking for Homebrew installation...' >&2
 if command -v -- brew >/dev/null 2>&1; then
-  command printf -- '  \342\234\205  found\n' >&2
-  command printf -- '\360\237\215\272  checking for Homebrew updates...\n' >&2
+  command -p -- printf -- '  \342\234\205  found\n' >&2
+  command -p -- printf -- '\360\237\215\272  checking for Homebrew updates...\n' >&2
   command brew update
   command defaults export com.apple.dock "${TMPDIR:-${TMPPREFIX:-/tmp}}"'/.com.apple.dock.plist' >/dev/null 2>&1 && {
     command brew upgrade --cask --greedy
@@ -39,97 +39,97 @@ if command -v -- brew >/dev/null 2>&1; then
   command brew install --debug --display-times --git --HEAD --verbose -- shellcheck
   command brew install --debug --display-times --git --HEAD --verbose -- shfmt
   command brew install --debug --display-times --git --HEAD --verbose -- zsh
-else command printf -- 'No Homebrew installation detected.\n\n' >&2; fi
-command printf -- '\360\237\217\224  checking for Alpine Package Keeper installation...\n' >&2
+else command -p -- printf -- 'No Homebrew installation detected.\n\n' >&2; fi
+command -p -- printf -- '\360\237\217\224  checking for Alpine Package Keeper installation...\n' >&2
 if command -v -- apk >/dev/null 2>&1; then
-  command printf -- '\360\237\217\224  apk update...\n' >&2
+  command -p -- printf -- '\360\237\217\224  apk update...\n' >&2
   command apk update --progress --verbose --verbose
-  command printf -- '\n\360\237\217\224  apk upgrade...\n' >&2
+  command -p -- printf -- '\n\360\237\217\224  apk upgrade...\n' >&2
   command apk upgrade --progress --update-cache --verbose --verbose
-  command printf -- '\n\360\237\217\224  apk fix...\n' >&2
+  command -p -- printf -- '\n\360\237\217\224  apk fix...\n' >&2
   command apk fix --progress --verbose --verbose
-  command printf -- '\n\360\237\217\224  apk verify...\n' >&2
+  command -p -- printf -- '\n\360\237\217\224  apk verify...\n' >&2
   command apk verify --progress --verbose --verbose
-  command printf -- '\360\237\217\224  apk verify complete...\n\n' >&2
-else command printf -- 'no Alpine Package Keeper installation detected.\n\n' >&2; fi
-command printf -- 'checking access to Software Update...\n' >&2
+  command -p -- printf -- '\360\237\217\224  apk verify complete...\n\n' >&2
+else command -p -- printf -- 'no Alpine Package Keeper installation detected.\n\n' >&2; fi
+command -p -- printf -- 'checking access to Software Update...\n' >&2
 if command -v -- softwareupdate >/dev/null 2>&1; then
-  command printf -- '\360\237\215\216  ' >&2
+  command -p -- printf -- '\360\237\215\216  ' >&2
   command softwareupdate --all --list --verbose
-else command printf -- 'no Software Update installation detected.\n\n' >&2; fi
-command printf -- 'checking for Xcode installation...\n' >&2
+else command -p -- printf -- 'no Software Update installation detected.\n\n' >&2; fi
+command -p -- printf -- 'checking for Xcode installation...\n' >&2
 if command -v -- xcrun >/dev/null 2>&1; then
-  command printf -- 'removing unavailable device simulators...\n' >&2
+  command -p -- printf -- 'removing unavailable device simulators...\n' >&2
   command xcrun simctl delete unavailable
-else command printf -- 'no Xcode installation detected.\n\n' >&2; fi
-command printf -- '\342\232\233\357\270\217  checking for Atom installation...\n' >&2
-if command -v -- apm >/dev/null 2>&1; then command apm upgrade --no-confirm; else command printf -- 'no Atom installation detected.\n\n' >&2; fi
-command printf -- '\360\237\214\240  checking for Cabal installation...\n' >&2
-if command -v -- cabal >/dev/null 2>&1; then command cabal update --verbose; else command printf -- 'no Cabal installation detected.\n\n' >&2; fi
-command printf -- '\360\237\246\200  checking for Rust installation...\n' >&2
-if command -v -- rustup >/dev/null 2>&1; then command rustup --verbose update; else command printf -- 'no Rust installation detected.\n\n' >&2; fi
-command printf -- 'checking for npm installation...\n' >&2
+else command -p -- printf -- 'no Xcode installation detected.\n\n' >&2; fi
+command -p -- printf -- '\342\232\233\357\270\217  checking for Atom installation...\n' >&2
+if command -v -- apm >/dev/null 2>&1; then command apm upgrade --no-confirm; else command -p -- printf -- 'no Atom installation detected.\n\n' >&2; fi
+command -p -- printf -- '\360\237\214\240  checking for Cabal installation...\n' >&2
+if command -v -- cabal >/dev/null 2>&1; then command cabal update --verbose; else command -p -- printf -- 'no Cabal installation detected.\n\n' >&2; fi
+command -p -- printf -- '\360\237\246\200  checking for Rust installation...\n' >&2
+if command -v -- rustup >/dev/null 2>&1; then command rustup --verbose update; else command -p -- printf -- 'no Rust installation detected.\n\n' >&2; fi
+command -p -- printf -- 'checking for npm installation...\n' >&2
 if command -v -- npm >/dev/null 2>&1; then
-  command printf -- '...and whether this device is can update npm quickly...\n' >&2
-  if test "$(command getconf -- LONG_BIT)" -gt 32; then
-    while test "$(command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
+  command -p -- printf -- '...and whether this device is can update npm quickly...\n' >&2
+  if test "$(command -p -- getconf -- LONG_BIT)" -gt 32; then
+    while test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
     command npm install --location=global --loglevel=verbose -- npm
-    while test "$(command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
+    while test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
     command npm update --location=global --loglevel=verbose
   else
-    command printf -- 'skipping npm update...\n\n' >&2
-    command sleep 1
-    command printf -- 'to update npm later, run:\n\n' >&2
-    command printf -- '    npm install --location=global npm \046\046 \134\n' >&2
-    command printf -- '    npm update --location=global --loglevel=verbose\n\n\n' >&2
-    command sleep 3
+    command -p -- printf -- 'skipping npm update...\n\n' >&2
+    command -p -- sleep 1
+    command -p -- printf -- 'to update npm later, run:\n\n' >&2
+    command -p -- printf -- '    npm install --location=global npm \046\046 \134\n' >&2
+    command -p -- printf -- '    npm update --location=global --loglevel=verbose\n\n\n' >&2
+    command -p -- sleep 3
   fi
   command npm ls --json --location=global --loglevel=verbose >"${DOTFILES:-${HOME%/}}"'/.package-list.json'
-else command printf -- 'no npm installation detected.\n\n' >&2; fi
-command printf -- 'checking for RubyGems installation...\n' >&2
+else command -p -- printf -- 'no npm installation detected.\n\n' >&2; fi
+command -p -- printf -- 'checking for RubyGems installation...\n' >&2
 if command -v -- gem >/dev/null 2>&1; then
-  command printf -- 'updating RubyGems...\n' >&2
+  command -p -- printf -- 'updating RubyGems...\n' >&2
   command gem update --system --verbose
   command gem update --verbose
   if command bundle update >/dev/null 2>&1; then command bundle update --verbose 2>/dev/null; fi
   if command bundle install >/dev/null 2>&1; then command bundle install --verbose 2>/dev/null; fi
-  command printf -- 'checking for CocoaPods installation...\n' >&2
+  command -p -- printf -- 'checking for CocoaPods installation...\n' >&2
   if command bundle exec pod install >/dev/null 2>&1; then command bundle exec pod install --verbose 2>/dev/null; fi
   if command pod repo update >/dev/null 2>&1; then
     command pod repo update --verbose
     command pod repo update --verbose
   fi
-else command printf -- 'no RubyGems installation detected.\n\n' >&2; fi
+else command -p -- printf -- 'no RubyGems installation detected.\n\n' >&2; fi
 if command -v -- rbenv >/dev/null 2>&1; then command rbenv rehash; fi
 if command -v -- c_rehash >/dev/null 2>&1; then command c_rehash; fi
 if command -v -- python3 >/dev/null 2>&1; then
-  command printf -- '\n\360\237\220\215  verifying Python\342\200\231s packager is up to date...\n' >&2
+  command -p -- printf -- '\n\360\237\220\215  verifying Python\342\200\231s packager is up to date...\n' >&2
   command python3 -m pip install --upgrade --verbose --verbose -- pip
-  command printf -- 'verifying pip installation...\n' >&2
+  command -p -- printf -- 'verifying pip installation...\n' >&2
   if command python3 -m pip >/dev/null 2>&1; then
-    command printf -- '\n\360\237\220\215  updating outdated Python packages...\n' >&2
-    command python3 -m pip list --format=columns --outdated | command sed -n -e '3,$ s/^\([^[:space:]]*\).*/\1/p' | while IFS='' read -r -- package; do command python3 -m pip install --upgrade --verbose --verbose -- "${package-}"; done
+    command -p -- printf -- '\n\360\237\220\215  updating outdated Python packages...\n' >&2
+    command python3 -m pip list --format=columns --outdated | command -p -- sed -n -e '3,$ s/^\([^[:space:]]*\).*/\1/p' | while IFS='' read -r -- package; do command python3 -m pip install --upgrade --verbose --verbose -- "${package-}"; done
     package=''
     unset -v -- package 2>/dev/null
   fi
-  command printf -- 'checking for pyenv installation...\n' >&2
+  command -p -- printf -- 'checking for pyenv installation...\n' >&2
   if command -v -- pyenv >/dev/null 2>&1; then
-    command printf -- 'rehashing pyenv shims...\n' >&2
+    command -p -- printf -- 'rehashing pyenv shims...\n' >&2
     command pyenv rehash
-  else command printf -- 'no pyenv installation detected.\n\n' >&2; fi
-  command printf -- 'checking for Conda installation...\n' >&2
-  if command -v -- conda >/dev/null 2>&1; then command conda update --all --yes; else command printf -- 'no Conda installation detected.\n\n' >&2; fi
+  else command -p -- printf -- 'no pyenv installation detected.\n\n' >&2; fi
+  command -p -- printf -- 'checking for Conda installation...\n' >&2
+  if command -v -- conda >/dev/null 2>&1; then command conda update --all --yes; else command -p -- printf -- 'no Conda installation detected.\n\n' >&2; fi
 fi
 if command -v -- brew >/dev/null 2>&1; then
   command brew generate-man-completions --debug --verbose 2>/dev/null
-  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command awk -F '\t' -- '{print $2 $1}' | command sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command sort -f | {
-    command printf -- '#!/usr/bin/env ruby\n'
-    command sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/'
+  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command -p -- sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command -p -- awk -F '\t' -- '{print $2 $1}' | command -p -- sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command -p -- sort -f | {
+    command -p -- printf -- '#!/usr/bin/env ruby\n'
+    command -p -- sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/'
   } >"${HOME%/}"'/.Brewfile'
 fi
 if command -v -- omz >/dev/null 2>&1; then omz update 2>/dev/null; fi
 if command -v -- rehash >/dev/null 2>&1; then rehash; fi
 update=''
 unset -v -- update 2>/dev/null
-command printf -- '\n\342%s\234\205  update complete\n' "${update-}" >&2
+command -p -- printf -- '\n\342%s\234\205  update complete\n' "${update-}" >&2
 case "${SHELL##*/}" in *"${0##*-}") return ;; *) exit ;; esac

--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-update='2024-01-11'
+update='2024-01-12'
 IFS="$(command -p -- printf -- ' \t\n|')" && IFS="${IFS%'|'}"
 command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
 command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
@@ -122,7 +122,7 @@ if command -v -- python3 >/dev/null 2>&1; then
 fi
 if command -v -- brew >/dev/null 2>&1; then
   command brew generate-man-completions --debug --verbose 2>/dev/null
-  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command -p -- sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command -p -- awk -F '\t' -- '{print $2 $1}' | command -p -- sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command -p -- sort -f | {
+  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command -p -- sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command -p -- sed -e 's/\(.*\)\t\(.*\)/\2\1/' | command -p -- sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command -p -- sort -f | {
     command -p -- printf -- '#!/usr/bin/env ruby\n'
     command -p -- sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/'
   } >"${HOME%/}"'/.Brewfile'


### PR DESCRIPTION
Prepending POSIX-guaranteed utilities with `command -p` instead of just `command` is more dependable. It provides mroe replicability by avoiding potentially hazardous calls to less secure aliases and symbolic links and will fix #41.