### PR TITLE
keep `npm` recommendations consistent

### DIFF
--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-update='2024-01-12'
+update='2024-01-13'
 IFS="$(command -p -- printf -- ' \t\n|')" && IFS="${IFS%'|'}"
 command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
 command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
@@ -81,7 +81,7 @@ if command -v -- npm >/dev/null 2>&1; then
     command -p -- sleep 1
     command -p -- printf -- 'to update npm later, run:\n\n' >&2
     command -p -- printf -- '    npm install --location=global npm \046\046 \134\n' >&2
-    command -p -- printf -- '    npm update --location=global --loglevel=verbose\n\n\n' >&2
+    command -p -- printf -- '    npm update --location=global\n\n\n' >&2
     command -p -- sleep 3
   fi
   command npm ls --json --location=global --loglevel=verbose >"${DOTFILES:-${HOME%/}}"'/.package-list.json'


### PR DESCRIPTION
skip recommending `npm`’s `--verbose` option to fix #43

`npm up -g --log-level=verbose` was later printed as
`npm up -g --log-level=verbose`, but
`npm i  -g --log-level=verbose npm` was later printed as
`npm i  -g                     npm`, without `--log-level=verbose`, which is more appropriate for both
