### PR TITLE
perf: prepend all `test` calls with `command -p`

### DIFF
--- a/update
+++ b/update
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
-update='2024-01-14'
+update='2024-01-15'
 IFS="$(command -p -- printf -- ' \t\n|')" && IFS="${IFS%'|'}"
 command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
 command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
 command -p -- sleep 1
 i='0'
-while test "${i-}" -lt "$(command -p -- getconf -- CHAR_MAX)"; do
-  if test "$((i / 3 % 2))" -eq '0'; then command -p -- printf -- '.' >&2; else command -p -- printf -- '\b' >&2; fi
+while command -p -- test "${i-}" -lt "$(command -p -- getconf -- CHAR_MAX)"; do
+  if command -p -- test "$((i / 3 % 2))" -eq '0'; then command -p -- printf -- '.' >&2; else command -p -- printf -- '\b' >&2; fi
   i="$((i + 1))"
 done
 i=''
@@ -71,10 +71,10 @@ if command -v -- rustup >/dev/null 2>&1; then command rustup --verbose update; e
 command -p -- printf -- 'checking for npm installation...\n' >&2
 if command -v -- npm >/dev/null 2>&1; then
   command -p -- printf -- '...and whether this device is can update npm quickly...\n' >&2
-  if test "$(command -p -- getconf -- LONG_BIT)" -gt 32; then
-    while test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
+  if command -p -- test "$(command -p -- getconf -- LONG_BIT)" -gt 32; then
+    while command -p -- test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
     command npm install --location=global --loglevel=verbose --no-fund -- npm
-    while test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
+    while command -p -- test "$(command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -print)" != ''; do command -p -- find -- "$(command npm config --location=global get prefix)" -name '.DS_Store' -type f -delete; done
     command npm update --location=global --loglevel=verbose --no-fund
   else
     command -p -- printf -- 'skipping npm update...\n\n' >&2


### PR DESCRIPTION
Prepending POSIX-guaranteed utilities with `command -p` is more dependable and provides better replicability by avoiding potentially hazardous calls to less secure aliases or symbolic links.

Fix #45; see also #41.