### PR TITLE
fix: ensure `rubocop`-compliant `Brewfile`

### DIFF
--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-update='2024-04-17'
+update='2024-04-21'
 command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
 command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
 command -p -- sleep 1
@@ -118,10 +118,11 @@ if command -v -- python3 >/dev/null 2>&1; then
 fi
 if command -v -- brew >/dev/null 2>&1; then
   command brew generate-man-completions --debug --verbose 2>/dev/null
-  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command -p -- sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command -p -- sed -e 's/\(.*\)\t\(.*\)/\2\1/' | command -p -- sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command -p -- sort -f | {
+  command brew bundle dump --all --cask --debug --describe --file=- --force --formula --mas --no-restart --tap --verbose --vscode --whalebrew | command -p -- sed -e '/#/! s/"/'\''/g' | command -p -- sed -e '$! N' -e '/^#.*\n[^#]/ s/\n/\t/' -e 'P' -e 'D' | command -p -- sed -e 's/\(.*\)\t\(.*\)/\2\1/' | command -p -- sed -e 's/^\(tap\)/1\1/' -e 's/^\(brew\)/2\1/' -e 's/^\(cask\)/3\1/' | LC_ALL='C' command -p -- sort -f | {
     command -p -- printf -- '#!/usr/bin/env ruby\n'
+    command -p -- printf -- '# frozen_string_literal: true\n\n'
     command -p -- sed -e 's/^[[:digit:]]//' -e 's/\([^#]*\)\(#.*\)/\2\n\1/'
-  } >"${HOMEBREW_BUNDLE_FILE_GLOBAL:-${HOMEBREW_BUNDLE_FILE:-${HOME%/}/.Brewfile}}"
+  } >"${HOMEBREW_BUNDLE_FILE_GLOBAL:-${HOMEBREW_BUNDLE_FILE:-${HOME%/}/.Brewfile}}" && command -p -- chmod -- 755 "${HOMEBREW_BUNDLE_FILE_GLOBAL:-${HOMEBREW_BUNDLE_FILE:-${HOME%/}/.Brewfile}}"
 fi
 if command -v -- omz >/dev/null 2>&1; then omz update 2>/dev/null; fi
 if command -v -- rehash >/dev/null 2>&1; then rehash; fi


### PR DESCRIPTION
to fix [#59](https://github.com/LucasLarson/update/issues/59):
- replace double quotes with single quotes ([`Style/StringLiterals`](https://github.com/rubocop/rubocop/blob/56fe9e6338/docs/modules/ROOT/pages/cops_style.adoc#stylestringliterals))
```sh
sed '/#/! s/"/'\''/g'
```
- add line `# frozen_string_literal: true` ([`Style/FrozenStringLiteralComment`](https://github.com/rubocop/rubocop/blob/56fe9e6338/docs/modules/ROOT/pages/cops_style.adoc#stylefrozenstringliteralcomment)) and subsequent blank line ([`Layout/EmptyLineAfterMagicComment`](https://github.com/rubocop/rubocop/blob/45ba7790b3/docs/modules/ROOT/pages/cops_layout.adoc#layoutemptylineaftermagiccomment))
```sh
printf '# frozen_string_literal: true\n\n'
```
- set `Brewfile` permissions to executable ([`Lint/ScriptPermission`](https://github.com/rubocop/rubocop/blob/56fe9e6338/docs/modules/ROOT/pages/cops_lint.adoc#lintscriptpermission))
```sh
chmod 755 ~/.Brewfile
```