### PR TITLE
fix: repair update-available behavior

### DIFF
--- a/update
+++ b/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-update='2024-04-21'
+update='2024-04-25'
 command -p -- printf -- '\n\n                 .___       __\n __ ________   __\174 _\057____ _\057  \174_  ____\n\174  \174  \134____ \134 \057 __ \174\134__  \134\134   __\134\057 __ \134\n\174  \174  \057  \174_\076 \076 \057_\057 \174 \057 __ \134\174  \174 \134  ___\057\n\174____\057\174   __\057\134____ \174\050____  \057__\174  \134___  \076\n      \174__\174        \134\057     \134\057          \134\057\n a Lucas Larson production\n\n' >&2 && command -p -- sleep 1
 command -p -- printf -- '\360\237\223\241  verifying network connectivity' >&2
 command -p -- sleep 1
@@ -19,7 +19,7 @@ set -- 'https://lucaslarson.net/update'
 command -p -- test "$({ command wget --hsts-file=/dev/null --output-document=- --quiet -- "${1-}" || command curl --location --silent -- "${1-}"; } 2>/dev/null | command -p -- sed -n -e '/update=/ {' -e 's/[^[:digit:]]//gp' -e 'q' -e '}')" -le "$(command -p -- printf -- '%s\n' "${update-}" | command -p -- sed -e 's/[^[:digit:]]//g')" || {
   command -p -- printf -- 'An update to this updater is available\041 Download it here:\n%s\n' "${1-}" >&2
   unset -v -- update 2>/dev/null || update=''
-  exit
+  case "${SHELL##*/}" in *"${0##*-}") return "${update:-1}" ;; *) exit "${update:-1}" ;; esac
 }
 command -p -- printf -- '\360\237\215\272  checking for Homebrew installation...' >&2
 if command -v -- brew >/dev/null 2>&1; then


### PR DESCRIPTION
ensure that the script `return`s if run interactively and that it otherwise `exit`s if a newer version is available

related to #32
